### PR TITLE
Name reference saved to Resources

### DIFF
--- a/lib/resource.js
+++ b/lib/resource.js
@@ -3,7 +3,8 @@ var util = require('util');
 
 module.exports = Resource;
 
-function Resource() {
+function Resource(name) {
+  this.name = name;
   this.stack = [];
 }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -18,7 +18,7 @@ Server.prototype.resource = function (name, resource) {
   if (resource === undefined) {
     resource = this.resources[name];
     if (resource) return resource;
-    resource = new Resource();
+    resource = new Resource(name);
   }
 
   this.resources[name] = resource;


### PR DESCRIPTION
In my middleware, I am persisting to LevelDB store. I need to know which "Resource" to store to when the stack is called.

This was the only way I could figure it out.

"req.resource.name" , then we know this must go to the "messages" SubDB as an example.